### PR TITLE
Esdras session expiration

### DIFF
--- a/src/clj/y_video_back/routes/service_handlers/utils/role_utils.clj
+++ b/src/clj/y_video_back/routes/service_handlers/utils/role_utils.clj
@@ -2,6 +2,7 @@
   (:require [y-video-back.layout :refer [error-page]]
             [y-video-back.db.core :as db]
             [y-video-back.db.users :as users]
+            [y-video-back.config :refer [env]]
             [y-video-back.db.permissions :as permissions]
             [y-video-back.db.auth-tokens :as auth-tokens]
             [y-video-back.utils.account-permissions :as ac]
@@ -74,28 +75,16 @@
   (let [user-colls (users/READ-COLLECTIONS-BY-USER-VIA-COURSES user-id)]
     (contains? (set (map #(:id %) user-colls)) collection-id)))
 
-; (defn get-new-session-id
-;   ; "Generate new session-id, associated with same user as given session-id. Invalidate old session-id."
-;   "TODO: If the session-id time stamp is still within certain time then we do not renew"
-;   [session-id]
-;   (let [new-session-id (:id (auth-tokens/CREATE {:user-id (:user-id (auth-tokens/READ-UNEXPIRED session-id))}))]
-;     (auth-tokens/DELETE session-id)
-;     new-session-id))
-
 (defn get-new-session-id
   ; "Generate new session-id, associated with same user as given session-id. Invalidate old session-id."
-  "TODO: If the session-id time stamp is still within certain time then we do not renew"
+  "If the session-id time stamp is still within certain time then we do not renew"
   [session-id]
   (let [current-session (auth-tokens/READ-UNEXPIRED session-id)]
-    (if (> (- (inst-ms (java.time.Instant/now)) (inst-ms (get current-session :created))) 120000)
-      ;Instead of returning a new session-id return to the CAS login page or logout the user
-      ;; ((let [new-session-id (:id (auth-tokens/CREATE {:user-id (:user-id (auth-tokens/READ-UNEXPIRED session-id))}))]
-      ;;    (auth-tokens/DELETE session-id)
-      ;;    new-session-id))
+    (if (> (- (inst-ms (java.time.Instant/now)) (inst-ms (get current-session :created))) (-> env :SESSION_TIMEOUT))
       (let [c-id session-id] 
         (auth-tokens/DELETE c-id) "expired")
       (let [c-id session-id] 
-        (db/UPDATE :auth-tokens c-id (assoc current-session :created (java.time.Instant/now))) c-id))));add 4 hours to the created time 
+        (db/UPDATE :auth-tokens c-id (assoc current-session :created (java.time.Instant/now))) c-id))));add 4 hours to current session or in other words renew the creating date
 
 (def forbidden-page
   (error-page {:status 401, :title "401 - Unauthorized",


### PR DESCRIPTION
Changed the way session ID works. Instead of renewing a session id with each call we keep the same session id and update the time created time. After 4 hrs of the session id not renewing with an API call, the session id is deleted and the application logs the user out automatically. 