### PR TITLE
Changed the way users are created

### DIFF
--- a/src/clj/y_video_back/routes/service_handlers/handlers/user_handlers.clj
+++ b/src/clj/y_video_back/routes/service_handlers/handlers/user_handlers.clj
@@ -10,7 +10,8 @@
    [y-video-back.model-specs :as sp]
    [y-video-back.routes.service-handlers.utils.utils :as utils]
    [y-video-back.routes.service-handlers.utils.role-utils :as ru]
-   [y-video-back.course-creator :as cc]))
+   [y-video-back.course-creator :as cc]
+   [y-video-back.apis.persons :as persons]))
 
 (def user-create
   {:summary "Creates a new user - FOR DEVELOPMENT ONLY"
@@ -26,7 +27,13 @@
                  :body {:message "username already taken"}}
                 {:status 200
                  :body {:message "1 user created"
-                        :id (utils/get-id (users/CREATE body))}}))})
+                        :id (let [body body
+                                  byu-data (dissoc (persons/get-user-data (:username body)) :byu-id)
+                                  res (assoc body
+                                             :account-name (get byu-data :full-name)
+                                             :account-type (int (:account-type byu-data))
+                                             :email (get byu-data :email))]
+                              (utils/get-id (users/CREATE res)))}}))})
 
 (def user-get-by-id
   {:summary "Retrieves specified user"


### PR DESCRIPTION
Users automatically get data from byu before they get created. If data is available it will be provided by the BYU API. If data is not available dummy data will be included in those fields. See api/persons/get-user-data for more information