### PR TITLE
User delete and admin getting collection fixed

### DIFF
--- a/src/clj/y_video_back/routes/service_handlers/handlers.clj
+++ b/src/clj/y_video_back/routes/service_handlers/handlers.clj
@@ -24,6 +24,7 @@
 (def user-get-by-id users/user-get-by-id)
 (def user-update users/user-update)
 (def user-delete users/user-delete)
+(def user-delete-width-collections users/user-delete-with-collections)
 (def user-get-logged-in users/user-get-logged-in)
 (def user-get-all-collections users/user-get-all-collections)
 (def user-get-all-collections-by-logged-in users/user-get-all-collections-by-logged-in)

--- a/src/clj/y_video_back/routes/service_handlers/handlers/admin_handlers.clj
+++ b/src/clj/y_video_back/routes/service_handlers/handlers/admin_handlers.clj
@@ -35,7 +35,9 @@
                                   (db/read-all-pattern :collections-undeleted
                                                        [:collection-name]
                                                        (str "%" term "%")))
-                    res (map #(into % {:username (:username (users/READ (:owner %)))})
+                    res (map #(into % {:username (if (nil? (:username (users/READ (:owner %))))
+                                                   ""
+                                                   (:username (users/READ (:owner %))))})
                              coll-res)]
                 {:status 200
                  :body res}))})

--- a/src/clj/y_video_back/routes/services.clj
+++ b/src/clj/y_video_back/routes/services.clj
@@ -148,7 +148,8 @@
        :patch service-handlers/user-update
        :delete service-handlers/user-delete}]
      ["/{id}/collections"
-      {:get service-handlers/user-get-all-collections}]
+      {:get service-handlers/user-get-all-collections
+       :delete service-handlers/user-delete-width-collections}]
      ["/{id}/courses"
       {:get service-handlers/user-get-all-courses}]
      ["/{id}/words"


### PR DESCRIPTION
Added functionality in admin handler to account for collections that have no owner and returns nil. This happens because collections can still be there even if their respective owner was deleted. This is an edge case, but it is worth accounting for it in case that it happens.

Since users can be deleted and their collections remain there. I added a new delete method that will delete all the collections for the user that was marked for deletion.
If a collection is deleted, the respective content still remains there, but this content will never be called again because the collection does not exist.