### PR TITLE
Fix no name 2022251

### DIFF
--- a/src/clj/y_video_back/apis/persons.clj
+++ b/src/clj/y_video_back/apis/persons.clj
@@ -59,7 +59,7 @@
             full-name (get-in (get-cats-from-json json-res) ["basic" "preferred_name" "value"])
             byu-id (get-in (get-cats-from-json json-res) ["basic" "byu_id" "value"])
             email (first (filter #(not (nil? %)) [(get-email-from-json json-res), "none"]))
-            account-type (get-account-type netid json-res) ;; ERROR
+            account-type (get-account-type netid json-res)
             person-id (get-person-id-from-json json-res)]
         {:full-name full-name
          :byu-id byu-id

--- a/src/clj/y_video_back/apis/persons.clj
+++ b/src/clj/y_video_back/apis/persons.clj
@@ -21,18 +21,21 @@
                         (get-in (get-cats-from-json js) ["email_addresses" "values"]))))))
 
 (defn get-account-type-from-json
-  [js]
-  (if (= "FAC" (str/upper-case (get-in (get-cats-from-json js) ["employee_summary" "employee_classification_code" "value"])))
-    2
-    3))
+  [json-res]
+  (let [categories (get-cats-from-json json-res)
+        account-type (get-in categories ["employee_summary" "employee_classification_code" "value"])]
+    (if (and account-type
+             (= "FAC" (str/upper-case account-type)))
+      2
+      3)))
 
 (defn get-account-type ;; TODO debug
   "If username in user-type-exceptions, returns that value. Else, returns value from json."
-  [username js]
-  (let [exc-res (user-type-exceptions/READ-BY-USERNAME [username])]
-    (if (= 0 (count exc-res))
-      (get-account-type-from-json js)
-      (:account-type (first exc-res)))))
+  [netid json-res]
+  (let [exception-result (user-type-exceptions/READ-BY-USERNAME [netid])]
+    (if (empty? exception-result)
+      (get-account-type-from-json json-res)
+      (:account-type (first exception-result)))))
 
 (defn get-person-id-from-json
   [js]
@@ -40,7 +43,7 @@
 
 (defn get-user-data
   "Gets data from AcademicRecordsStudentStatusInfo"
-  [netid] ;; (def netid "nbown16")
+  [netid] ;; (def netid "nbown16") (def netid "rjr45")
   (if (= (:front-end-netid env) netid)
     {:full-name (str netid " no_name")
      :byu-id nil

--- a/src/clj/y_video_back/apis/persons.clj
+++ b/src/clj/y_video_back/apis/persons.clj
@@ -26,7 +26,7 @@
     2
     3))
 
-(defn get-account-type
+(defn get-account-type ;; TODO debug
   "If username in user-type-exceptions, returns that value. Else, returns value from json."
   [username js]
   (let [exc-res (user-type-exceptions/READ-BY-USERNAME [username])]
@@ -40,7 +40,7 @@
 
 (defn get-user-data
   "Gets data from AcademicRecordsStudentStatusInfo"
-  [netid]
+  [netid] ;; (def netid "nbown16")
   (if (= (:front-end-netid env) netid)
     {:full-name (str netid " no_name")
      :byu-id nil
@@ -56,7 +56,7 @@
             full-name (get-in (get-cats-from-json json-res) ["basic" "preferred_name" "value"])
             byu-id (get-in (get-cats-from-json json-res) ["basic" "byu_id" "value"])
             email (first (filter #(not (nil? %)) [(get-email-from-json json-res), "none"]))
-            account-type (get-account-type netid json-res)
+            account-type (get-account-type netid json-res) ;; ERROR
             person-id (get-person-id-from-json json-res)]
         {:full-name full-name
          :byu-id byu-id

--- a/src/clj/y_video_back/apis/persons.clj
+++ b/src/clj/y_video_back/apis/persons.clj
@@ -29,7 +29,7 @@
       2
       3)))
 
-(defn get-account-type ;; TODO debug
+(defn get-account-type
   "If username in user-type-exceptions, returns that value. Else, returns value from json."
   [netid json-res]
   (let [exception-result (user-type-exceptions/READ-BY-USERNAME [netid])]

--- a/src/clj/y_video_back/apis/utils.clj
+++ b/src/clj/y_video_back/apis/utils.clj
@@ -51,7 +51,3 @@
     new-token))
 
 (def oauth-token "")
-
-
-
-


### PR DESCRIPTION
  The problem we see on people like nbown16 (and I dare say on most of those getting the error) is that the check for account type is coming back with nothing, which was causing an error that was ill-caught. What I don't know is whether this should ever be expected (why do some people not get validation_response info from the Personsv3 service?).

Because it was an unhandled error based on getting nothing, I was able to fix it to where it should stay within the business logic. I did not change the logic -- I just caused it to no longer fail on a "not found".

The response that was causing failures looked like this (in part):

     {"metadata" {"validation_response" {"code" 404, "message" "Not Found"}, "validation_information" ["Employee record not found"]}}