### PR TITLE
forcing use of netid@byu.edu for work email address

### DIFF
--- a/src/clj/y_video_back/apis/persons.clj
+++ b/src/clj/y_video_back/apis/persons.clj
@@ -170,7 +170,7 @@
       {
         :full-name (str (data :preferred_first_name) " " (data :preferred_last_name))
         :byu-id byuid
-        :email (data :work_email_address)
+        :email (str netid "@byu.edu")
         :account-type (assign-account-type employee_type_data netid)
         :person-id personid
       }

--- a/src/clj/y_video_back/routes/services.clj
+++ b/src/clj/y_video_back/routes/services.clj
@@ -86,25 +86,29 @@
              :permission-level "master"
              :handler (fn [] "doesn't matter")}}]]
 
-    ;; now defunct, would have to add {byuid} and {personid} as parameters in the path and provide those to
-    ;; uc/get-session-id to get this to work. As far as I can tell, it was only ever used for testing. BDR 10/16/2024
-    ;; ["/get-session-id/{username}/{password}"
-    ;;  {:swagger {:tags ["auth"]}}
+    ;; To use this endpoint, the personid can be anything because it isn't really used downstream. The use of personid is an artifact from
+    ;; the old API integration implementation. It remains simply because it wasn't worth the effor to remove every mention of personid in
+    ;; in the old code since we were on a time crunch to deliver a version of Y-video that worked with the new APIs. In the methods that
+    ;; personid is passed to, personid value is set to all zeros. byuid must be populated and correct. BDR 5/16/2025
+     ["/get-session-id/{username}/{password}/{byuid}/{personid}"
+      {:swagger {:tags ["auth"]}}
 
-    ;;  [""
-    ;;   {:get {:summary "gets session id for username"
-    ;;          :parameters {:path {:username string?
-    ;;                              :password string?}}
-    ;;          :responses {200 {:body {:session-id string?}}
-    ;;                      403 {:body {:message string?}}}
-    ;;          :handler (fn [{{{:keys [username password]} :path} :parameters}]
-    ;;                     (if (nil? (:NEW-USER-PASSWORD env))
-    ;;                       {:status 401 :message "unauthorized"}
-    ;;                       (if-not (= (:NEW-USER-PASSWORD env) password)
-    ;;                         {:status 403
-    ;;                          :body {:message "incorrect password"}}
-    ;;                         {:status 200
-    ;;                          :body {:session-id (str (uc/get-session-id username))}})))}}]]
+      [""
+       {:get {:summary "gets session id for username"
+              :parameters {:path {:username string?
+                                  :password string?
+				    :byuid string?
+				    :personid string?}}
+              :responses {200 {:body {:session-id string?}}
+                          403 {:body {:message string?}}}
+              :handler (fn [{{{:keys [username password byuid personid]} :path} :parameters}]
+                         (if (nil? (:NEW-USER-PASSWORD env))
+                           {:status 401 :message "unauthorized"}
+                           (if-not (= (:NEW-USER-PASSWORD env) password)
+                             {:status 403
+                              :body {:message "incorrect password"}}
+                             {:status 200
+                              :body {:session-id (str (uc/get-session-id username byuid personid))}})))}}]]
 
     ["/echo"
      {:swagger {:tags ["echo"]}}


### PR DESCRIPTION
This is an old change that I never brought into master. It prevents an error from when the work_email_address is not defined. the netid is always there and since netid@byu.edu is always a valid email address, it is a safer address to use. In any case, I don't think Y-video uses email address for anything.